### PR TITLE
Output the layer to a tgz file

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"archive/tar"
 	"compress/gzip"
+	"bufio"
 	"flag"
 	"io"
 	"log"
@@ -13,16 +14,18 @@ import (
 )
 
 var layer int
+var output string
 
 func init() {
 	flag.IntVar(&layer, "layer", -1, "layer to extract from")
+	flag.StringVar(&output, "output", "", "output file")
 }
 
 func main() {
 	flag.Parse()
 
 	if flag.NArg() < 1 {
-		log.Fatalf("usage: register image[:tag] files...")
+		log.Fatalf("usage: regextract [--output=file.tgz] image[:tag] [files...]")
 	}
 	tag := "latest"
 	it := strings.SplitN(flag.Arg(0), ":", 2)
@@ -36,6 +39,10 @@ func main() {
 	fileset := make(map[string]bool)
 	for _, v := range files {
 		fileset[v] = true
+	}
+
+	if output != "" && flag.NArg() != 1 {
+		log.Fatalf("Cannot specify an output file when only some files are extracted")
 	}
 
 	url := "https://registry-1.docker.io/"
@@ -64,6 +71,23 @@ func main() {
 	}
 	defer reader.Close()
 
+	if output != "" {
+		f, err := os.Create(output)
+		if err != nil {
+			log.Fatalf("Unable to create file %s: %s", output, err)
+		}
+
+		out := bufio.NewWriter(f)
+		defer out.Flush()
+
+		_, err = io.Copy(out, reader)
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		return
+	}
+
 	unzipper, err := gzip.NewReader(reader)
 	if err != nil {
 		log.Fatalf("Cannot uncompress: %s", err)
@@ -71,6 +95,7 @@ func main() {
 
 	tr := tar.NewReader(unzipper)
 	tw := tar.NewWriter(os.Stdout)
+
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -79,17 +104,20 @@ func main() {
 		if err != nil {
 			log.Fatalln(err)
 		}
+
 		if fileset[hdr.Name] || allfiles {
 			err = tw.WriteHeader(hdr)
 			if err != nil {
 				log.Fatalf("cannot write to tar: %s", err)
 			}
+
 			_, err = io.Copy(tw, tr)
 			if err != nil {
 				log.Fatalln(err)
 			}
 		}
 	}
+
 	err = tw.Close()
 	if err != nil {
 		log.Fatalf("Tar close error: %s", err)


### PR DESCRIPTION
Outputing a tar file on stdout always produces a corrupted file on windows. I don't know if it's the stdout or the way we decompress/write uncompressed.

Signed-off-by: David Gageot david@gageot.net
