### PR TITLE
Add CircleCI build for multiple platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+regextract

--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ You can specify the files you want to extract eg
 regextract library/alpine bin/busybox | tar xf -
 ```
 Will extract busybox from Alpine (note lack of leading `/`).
+
+Binary artifacts for amd64 architectures are built by CI:
+
+- [MacOS](https://circleci.com/api/v1/project/justincormack/regextract/latest/artifacts/0/$CIRCLE_ARTIFACTS/darwin/amd64/regextract)
+- [Linux](https://circleci.com/api/v1/project/justincormack/regextract/latest/artifacts/0/$CIRCLE_ARTIFACTS/linux/amd64/regextract)
+- [Windows](https://circleci.com/api/v1/project/justincormack/regextract/latest/artifacts/0/$CIRCLE_ARTIFACTS/windows/amd64/regextract.exe)

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,9 @@
+machine:
+    environment:
+        PROJECT: $CIRCLE_PROJECT_REPONAME
+        IMPORT:  github.com/$CIRCLE_PROJECT_USERNAME/$PROJECT
+test:
+    post:
+        - GOOS=linux   GOARCH=amd64 go build -o $CIRCLE_ARTIFACTS/linux/amd64/$PROJECT       $IMPORT
+        - GOOS=darwin  GOARCH=amd64 go build -o $CIRCLE_ARTIFACTS/darwin/amd64/$PROJECT      $IMPORT
+        - GOOS=windows GOARCH=amd64 go build -o $CIRCLE_ARTIFACTS/windows/amd64/$PROJECT.exe $IMPORT


### PR DESCRIPTION
Use golang's cross support to build for MacOS, Linux and Windows
AMD64 architectures.

Signed-off-by: Robb Kistler <robb.kistler@docker.com>